### PR TITLE
Client config using env vars and window object

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+REACT_APP_DASH_API_URL=http://localhost:9090

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -12,7 +12,11 @@ COPY src/ ./src/
 RUN npm run build
 
 FROM nginx:stable-alpine
+RUN apk add --no-cache jq
+
 COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 80
 
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/README.md
+++ b/client/README.md
@@ -18,10 +18,10 @@ docker build -t app-dash-client .
 ```
 
 - Then, run the container and map the port
-    - Be sure to set the environment variable for the `APP_DASH_API_URL`
+    - Be sure to set the environment variable for the `REACT_APP_DASH_API_URL`
 
 ```shell
-docker run -p 3001:80 -e APP_DASH_API_URL='http://localhost:8080' app-dash-client
+docker run -p 3001:80 -e REACT_APP_DASH_API_URL='http://localhost:9090' app-dash-client
 ```
     
 - Access the site at [http://localhost:3001](http://localhost:3001)
@@ -33,6 +33,8 @@ npm i --silent
 ```
     
 - Invoke the `start` command from `react-scripts`
+    - The URL for the server is set in the `.env` file as a default to the localhost server
+    - See the React docs [Adding Custom Environment Variables](https://create-react-app.dev/docs/adding-custom-environment-variables/) for ways to override this.
 
 ```shell
 npm start

--- a/client/README.md
+++ b/client/README.md
@@ -7,7 +7,9 @@ It's built with [React](https://reactjs.org/) and [MaterialUI](https://mui.com/)
 The client can be run as a Docker container, or locally for development.
 
 ### Docker container
-The container uses an entrypoint script that will read the environment variables that start with `APP_DASH_` and add them to the `window.ENV` object.
+The container uses an entrypoint script that will read the environment variables that start with `REACT_APP_` and add them to the `window.ENV` object.
+
+> Thanks to [axelhzf](https://github.com/axelhzf)'s repo: [create-react-app-docker-environment-variables](https://github.com/axelhzf/create-react-app-docker-environment-variables)
 
 This is how the api url is accessed at runtime allowing you to deploy this client code using different backends as desired.
 

--- a/client/README.md
+++ b/client/README.md
@@ -4,29 +4,41 @@ This is the main UI for the "App-Dash" project.
 It's built with [React](https://reactjs.org/) and [MaterialUI](https://mui.com/)
 
 ## Run
-The client can be run as a Docker container, or locally for development
+The client can be run as a Docker container, or locally for development.
 
-- Docker container
-    - First, build the image
-```bash
+### Docker container
+The container uses an entrypoint script that will read the environment variables that start with `APP_DASH_` and add them to the `window.ENV` object.
+
+This is how the api url is accessed at runtime allowing you to deploy this client code using different backends as desired.
+
+- First, build the image
+    
+```shell
 docker build -t app-dash-client .
 ```
-    - Then, run the container and map the port
-```bash
-docker run -p 3001:80 app-dash-client
-```
-    - Access the site at [http://localhost:3001](http://localhost:3001)
 
-- Locally
-    - First, be sure the node_modules are installed
-```bash
+- Then, run the container and map the port
+    - Be sure to set the environment variable for the `APP_DASH_API_URL`
+
+```shell
+docker run -p 3001:80 -e APP_DASH_API_URL='http://localhost:8080' app-dash-client
+```
+    
+- Access the site at [http://localhost:3001](http://localhost:3001)
+
+### Locally
+- First, be sure the node_modules are installed
+```shell
 npm i --silent
 ```
-    - Invoke the `start` command from `react-scripts`
-```bash
+    
+- Invoke the `start` command from `react-scripts`
+
+```shell
 npm start
 ```
-    - Access the site at [http://localhost:3000](http://localhost:3000)
+
+- Access the site at [http://localhost:3000](http://localhost:3000)
 
 
 ## Create React App (Generated)

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Capture all environment variables starting with APP_DASH_ and make JSON string from them
-ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("APP_DASH_")))')"
+ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("REACT_APP_")))')"
 
 # Escape sed replacement's special characters: \, &, /.
 # No need to escape newlines, because --compact-output already removed them.

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -euo pipefail
+
+# Capture all environment variables starting with APP_DASH_ and make JSON string from them
+ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("APP_DASH_")))')"
+
+# Escape sed replacement's special characters: \, &, /.
+# No need to escape newlines, because --compact-output already removed them.
+# Inside of JSON strings newlines are already escaped.
+ENV_JSON_ESCAPED="$(printf "%s" "${ENV_JSON}" | sed -e 's/[\&/]/\\&/g')"
+
+sed -i "s/<noscript id=\"env-insertion-point\"><\/noscript>/<script>var ENV=${ENV_JSON_ESCAPED}<\/script>/g" /usr/share/nginx/html/index.html
+
+exec "$@"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,7 +16,6 @@
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
         "axios": "^0.21.4",
-        "config": "^3.3.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0",
@@ -6409,17 +6408,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/config": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.6.tgz",
-      "integrity": "sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==",
-      "dependencies": {
-        "json5": "^2.1.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/confusing-browser-globals": {
@@ -26805,14 +26793,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "config": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.6.tgz",
-      "integrity": "sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==",
-      "requires": {
-        "json5": "^2.1.1"
       }
     },
     "confusing-browser-globals": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,6 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "axios": "^0.21.4",
-    "config": "^3.3.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -23,6 +23,9 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <noscript id="env-insertion-point"></noscript>
+
     <title>App Dash</title>
   </head>
   <body>

--- a/client/src/config/default.json
+++ b/client/src/config/default.json
@@ -1,5 +1,0 @@
-{
-    "server": {
-        "URI": "http://localhost:8080"
-    }
-}

--- a/client/src/config/docker.json
+++ b/client/src/config/docker.json
@@ -1,5 +1,0 @@
-{
-    "server": {
-        "URI": "http://localhost:9090"
-    }
-}

--- a/client/src/services/admin.js
+++ b/client/src/services/admin.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import authHeader from './authHeader';
 
-const API_URL = `${window.ENV.APP_DASH_API_URL}/admin`;
+const API_URL = `${window.ENV ? window.ENV.REACT_APP_DASH_API_URL : process.env.REACT_APP_DASH_API_URL}/admin`;
 // axios.create({baseUrl: API_URL}) wasn't working as expected
 const authConfig = {
     headers: authHeader()

--- a/client/src/services/admin.js
+++ b/client/src/services/admin.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import authHeader from './authHeader';
-import config from '../config/default.json';
 
-const API_URL = `${config.server.URI}/admin`
+const API_URL = `${window.ENV.APP_DASH_API_URL}/admin`;
 // axios.create({baseUrl: API_URL}) wasn't working as expected
 const authConfig = {
     headers: authHeader()

--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = window.ENV.APP_DASH_API_URL;
+const API_URL = window.ENV ? window.ENV.REACT_APP_DASH_API_URL : process.env.REACT_APP_DASH_API_URL
 
 const login = (password) => {
     return axios

--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
-import config from '../config/default.json';
 
-const API_URL = `${config.server.URI}`
+const API_URL = window.ENV.APP_DASH_API_URL;
 
 const login = (password) => {
     return axios

--- a/client/src/services/item.js
+++ b/client/src/services/item.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
-import config from '../config/default.json';
 
-const API_URL = `${config.server.URI}`
+const API_URL = window.ENV.APP_DASH_API_URL;
 
 const getAllItems = () => {
     return axios.get(API_URL);

--- a/client/src/services/item.js
+++ b/client/src/services/item.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = window.ENV.APP_DASH_API_URL;
+const API_URL = window.ENV ? window.ENV.REACT_APP_DASH_API_URL : process.env.REACT_APP_DASH_API_URL;
 
 const getAllItems = () => {
     return axios.get(API_URL);


### PR DESCRIPTION
Using environment variables for changing config values without
requiring a rebuild and deployment of the client code.
WIP need to adjust for use while running outside of docker.
Need a way to set the window.ENV without the docker-entrypoint
script so that the standard npm start can be use during development

Resolves #16 