### PR TITLE
Display items in groups or as unsorted list

### DIFF
--- a/src/app/navbar.js
+++ b/src/app/navbar.js
@@ -12,18 +12,19 @@ import {
     Typography,
 } from '@mui/material';
 import {
+    Apps,
     Login,
     Logout,
     Menu as MenuIcon,
     PlaylistAdd,
     DarkMode,
     LightMode,
-    Settings,
+    ViewColumn,
     ViewModule,
     AppRegistration
 } from '@mui/icons-material'
 import { useDispatch, useSelector } from "react-redux";
-import { toggleDarkMode, toggleManageMode } from "../features/app/appSlice";
+import { toggleDarkMode, toggleManageMode, toggleGroupMode } from "../features/app/appSlice";
 import { openCreate, openSignIn } from '../features/dialog/dialogSlice'
 import { signOut } from "../features/user/userSlice";
 
@@ -47,12 +48,20 @@ export const Navbar = () => {
         return appSettings.darkMode
     }
 
+    const isGroupMode = () => {
+        return appSettings.groupMode
+    }
+
     const manageClicked = () => {
         dispatch(toggleManageMode())
     }
 
     const addClicked = () => {
         dispatch(openCreate())
+    }
+
+    const groupModeClicked = () => {
+        dispatch(toggleGroupMode())
     }
 
     const signInOutClicked = () => {
@@ -115,6 +124,20 @@ export const Navbar = () => {
         })
     }
 
+    const groupModeItem = () => {
+
+        console.log(`Group mode: ${isGroupMode()}`)
+
+        const itemIcon = isGroupMode() ? <Apps fontSize='small' /> : <ViewColumn fontSize='small' />
+        const itemText = isGroupMode() ? "List" : "Grouped"
+
+        return createMenuItem({
+            clickHandler: groupModeClicked,
+            itemIcon,
+            itemText
+        })
+    }
+
     const signInOutItem = () => {
         if (appSettings.authDisabled)
             return
@@ -150,6 +173,7 @@ export const Navbar = () => {
                     >
                         {isEditor() && addItem()}
                         {isEditor() && manageItem()}
+                        {groupModeItem()}
                         {modeSelectItem()}
                         {signInOutItem()}
                     </Menu>

--- a/src/app/navbar.js
+++ b/src/app/navbar.js
@@ -125,9 +125,6 @@ export const Navbar = () => {
     }
 
     const groupModeItem = () => {
-
-        console.log(`Group mode: ${isGroupMode()}`)
-
         const itemIcon = isGroupMode() ? <Apps fontSize='small' /> : <ViewColumn fontSize='small' />
         const itemText = isGroupMode() ? "List" : "Grouped"
 

--- a/src/features/app/appSlice.js
+++ b/src/features/app/appSlice.js
@@ -2,7 +2,8 @@ import { createSlice } from "@reduxjs/toolkit"
 import { apiSlice } from "../api/apiSlice"
 
 const storageNames = {
-    darkMode: 'darkMode'
+    darkMode: 'darkMode',
+    groupMode: 'groupMode',
 }
 
 const appSlice = createSlice({
@@ -10,7 +11,8 @@ const appSlice = createSlice({
     initialState: {
         authDisabled: false,
         manageMode: false,
-        darkMode: false
+        darkMode: false,
+        groupMode: true,
     },
     reducers: {
         toggleManageMode: (state) => {
@@ -18,19 +20,26 @@ const appSlice = createSlice({
         },
         toggleDarkMode: (state) => {
             state.darkMode = !state.darkMode
+        },
+        toggleGroupMode: (state) => {
+            state.groupMode = !state.groupMode
         }
     },
     extraReducers(builder) {
         builder.addMatcher(appSlice.actions.toggleDarkMode.match, (state) => {
             localStorage.setItem(storageNames.darkMode, state.darkMode)
         })
+        builder.addMatcher(appSlice.actions.toggleGroupMode.match), (state) => {
+            localStorage.setItem(storageNames.groupMode, state.groupMode)
+        }
         builder.addMatcher(apiSlice.endpoints.getSettings.matchFulfilled, (state, { payload }) => {
             state.authDisabled = payload.authDisabled
             state.darkMode = localStorage.getItem(storageNames.darkMode)
+            state.groupMode = localStorage.getItem(storageNames.groupMode)
         })
     }
 })
 
-export const { toggleManageMode, toggleDarkMode } = appSlice.actions
+export const { toggleManageMode, toggleDarkMode, toggleGroupMode } = appSlice.actions
 
 export default appSlice.reducer

--- a/src/features/app/appSlice.js
+++ b/src/features/app/appSlice.js
@@ -11,8 +11,8 @@ const appSlice = createSlice({
     initialState: {
         authDisabled: false,
         manageMode: false,
-        darkMode: false,
-        groupMode: true,
+        darkMode: localStorage.getItem(storageNames.darkMode),
+        groupMode: localStorage.getItem(storageNames.groupMode)
     },
     reducers: {
         toggleManageMode: (state) => {
@@ -20,22 +20,16 @@ const appSlice = createSlice({
         },
         toggleDarkMode: (state) => {
             state.darkMode = !state.darkMode
+            localStorage.setItem(storageNames.darkMode, state.darkMode)
         },
         toggleGroupMode: (state) => {
             state.groupMode = !state.groupMode
+            localStorage.setItem(storageNames.groupMode, state.groupMode)
         }
     },
     extraReducers(builder) {
-        builder.addMatcher(appSlice.actions.toggleDarkMode.match, (state) => {
-            localStorage.setItem(storageNames.darkMode, state.darkMode)
-        })
-        builder.addMatcher(appSlice.actions.toggleGroupMode.match), (state) => {
-            localStorage.setItem(storageNames.groupMode, state.groupMode)
-        }
         builder.addMatcher(apiSlice.endpoints.getSettings.matchFulfilled, (state, { payload }) => {
             state.authDisabled = payload.authDisabled
-            state.darkMode = localStorage.getItem(storageNames.darkMode)
-            state.groupMode = localStorage.getItem(storageNames.groupMode)
         })
     }
 })

--- a/src/features/items/itemCard.js
+++ b/src/features/items/itemCard.js
@@ -19,9 +19,6 @@ export const ItemCard = (item) => {
     const dispatch = useDispatch()
     const [deleteItem, { error }] = useDeleteItemMutation()
     const isManaged = useSelector(state => state.app.manageMode)
-    const getCardHeight = () => {
-        return isManaged ? 125 : 75
-    }
 
     const setAvatar = () => {
         const { image, imageUrl } = data
@@ -50,7 +47,7 @@ export const ItemCard = (item) => {
 
 
     return (
-        <Card variant="outlined" sx={{ width: 275, height: getCardHeight() }}>
+        <Card key={data._id} variant="outlined" sx={{ width: 275 }}>
             <CardActionArea
                 target="_blank"
                 href={data.url}
@@ -62,7 +59,7 @@ export const ItemCard = (item) => {
                     avatar={setAvatar()}
                 />
             </CardActionArea>
-            {isManaged ? <CardActions disableSpacing >
+            {isManaged ? <CardActions disableSpacing sx={{ padding: 0, justifyContent: 'end' }} >
                 <IconButton color={'secondary'} aria-label="edit" onClick={() => editItemClicked(data)}>
                     <Edit />
                 </IconButton>

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -17,7 +17,29 @@ export const ItemGrid = () => {
     const groups = itemState.groups
 
     const renderGroups = () => {
-        return groups.map((currentGroup) => (
+        let ungroupedItems = <Box m={2}
+            width={300}
+            paddingBottom={4}
+            display="flex"
+            flexDirection="column"
+            gap={2}
+            alignItems="center"
+            justifyContent="start"
+            border={1}
+            borderRadius={2}
+            key={'ungrouped'}
+        >
+            <h3>Ungrouped</h3>
+            <Stack key={'ungrouped-stack'} spacing={2}>
+                {items
+                    .filter(x => x.group === '')
+                    .map((currentItem) => (
+                        <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
+                    ))}
+            </Stack>
+        </Box>
+
+        let groupedItems = groups.map((currentGroup) => (
             <Box m={2}
                 width={300}
                 paddingBottom={4}
@@ -32,22 +54,24 @@ export const ItemGrid = () => {
             >
                 <h3>{currentGroup}</h3>
                 <Stack key={`${currentGroup}-stack`} spacing={2}>
-                {items
-                    .filter(x => x.group === currentGroup)
-                    .map((currentItem) => (
-                        <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
-                    ))}
+                    {items
+                        .filter(x => x.group === currentGroup)
+                        .map((currentItem) => (
+                            <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
+                        ))}
                 </Stack>
             </Box>
         ))
+
+        return [ ungroupedItems, ...groupedItems]
     }
 
     const renderItems = () => {
         return items.map((currentItem) => (
-                    <Grid item xs key={currentItem._id}>
-                        <ItemCard item={currentItem} />
-                    </Grid>
-                ))
+            <Grid item xs key={currentItem._id}>
+                <ItemCard item={currentItem} />
+            </Grid>
+        ))
     }
 
     return (

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -31,7 +31,7 @@ export const ItemGrid = () => {
                 {groups.map((currentGroup) => (
                     <Box m={2}
                         width={300}
-                        height={500}
+                        paddingBottom={4}
                         display="flex"
                         flexDirection="column"
                         gap={2}
@@ -42,13 +42,13 @@ export const ItemGrid = () => {
                         key={currentGroup}
                     >
                         <h3>{currentGroup}</h3>
+                        <Stack key={`${currentGroup}-stack`} spacing={2}>
                         {items
                             .filter(x => x.group === currentGroup)
                             .map((currentItem) => (
-                                <Stack spacing={6}>
-                                    <ItemCard item={currentItem} />
-                                </Stack>
+                                <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
                             ))}
+                        </Stack>
                     </Box>
                 ))}
             </Grid>

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -17,18 +17,30 @@ export const ItemGrid = () => {
     return (
         <Box m="auto"
             display="flex"
-            width="80%"
+            maxWidth="95%"
             alignItems="center"
             justifyContent="center"
-            paddingTop="10px"
+            paddingTop="30px"
         >
             <Grid container
                 direction="row"
+                justifyContent="center"
                 spacing={{ xs: 2, md: 3 }}
                 columns={{ xs: 4, sm: 8, md: 12 }}
             >
                 {groups.map((currentGroup) => (
-                    <Grid spacing={2} item key={currentGroup}>
+                    <Box m={2}
+                        width={300}
+                        height={500}
+                        display="flex"
+                        flexDirection="column"
+                        gap={2}
+                        alignItems="center"
+                        justifyContent="start"
+                        border={1}
+                        borderRadius={2}
+                        key={currentGroup}
+                    >
                         <h3>{currentGroup}</h3>
                         {items
                             .filter(x => x.group === currentGroup)
@@ -37,7 +49,7 @@ export const ItemGrid = () => {
                                     <ItemCard item={currentItem} />
                                 </Stack>
                             ))}
-                    </Grid>
+                    </Box>
                 ))}
             </Grid>
         </Box>

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -10,7 +10,11 @@ export const ItemGrid = () => {
     useEffect(() => {
         prefetchItems()
     }, [])
-    const items = useSelector(state => state.items)
+    const itemState = useSelector(state => state.items)
+    const items = itemState.items
+    const groups = itemState.groups
+
+    // TODO: groups map -> container
 
     return (
         <Box m="auto"

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Stack } from "@mui/material";
 
 import { ItemCard } from './itemCard';
 import { usePrefetch } from "../api/apiSlice";
@@ -14,8 +14,6 @@ export const ItemGrid = () => {
     const items = itemState.items
     const groups = itemState.groups
 
-    // TODO: groups map -> container
-
     return (
         <Box m="auto"
             display="flex"
@@ -29,10 +27,18 @@ export const ItemGrid = () => {
                 spacing={{ xs: 2, md: 3 }}
                 columns={{ xs: 4, sm: 8, md: 12 }}
             >
-                {items.map((currentItem) => (
-                    <Grid item xs key={currentItem._id}>
-                        <ItemCard item={currentItem} />
-                    </Grid>))}
+                {groups.map((currentGroup) => (
+                    <Grid spacing={2} item key={currentGroup}>
+                        <h3>{currentGroup}</h3>
+                        {items
+                            .filter(x => x.group === currentGroup)
+                            .map((currentItem) => (
+                                <Stack spacing={6}>
+                                    <ItemCard item={currentItem} />
+                                </Stack>
+                            ))}
+                    </Grid>
+                ))}
             </Grid>
         </Box>
     )

--- a/src/features/items/itemGrid.js
+++ b/src/features/items/itemGrid.js
@@ -11,8 +11,44 @@ export const ItemGrid = () => {
         prefetchItems()
     }, [])
     const itemState = useSelector(state => state.items)
+    const groupMode = useSelector(state => state.app.groupMode)
+
     const items = itemState.items
     const groups = itemState.groups
+
+    const renderGroups = () => {
+        return groups.map((currentGroup) => (
+            <Box m={2}
+                width={300}
+                paddingBottom={4}
+                display="flex"
+                flexDirection="column"
+                gap={2}
+                alignItems="center"
+                justifyContent="start"
+                border={1}
+                borderRadius={2}
+                key={currentGroup}
+            >
+                <h3>{currentGroup}</h3>
+                <Stack key={`${currentGroup}-stack`} spacing={2}>
+                {items
+                    .filter(x => x.group === currentGroup)
+                    .map((currentItem) => (
+                        <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
+                    ))}
+                </Stack>
+            </Box>
+        ))
+    }
+
+    const renderItems = () => {
+        return items.map((currentItem) => (
+                    <Grid item xs key={currentItem._id}>
+                        <ItemCard item={currentItem} />
+                    </Grid>
+                ))
+    }
 
     return (
         <Box m="auto"
@@ -28,29 +64,7 @@ export const ItemGrid = () => {
                 spacing={{ xs: 2, md: 3 }}
                 columns={{ xs: 4, sm: 8, md: 12 }}
             >
-                {groups.map((currentGroup) => (
-                    <Box m={2}
-                        width={300}
-                        paddingBottom={4}
-                        display="flex"
-                        flexDirection="column"
-                        gap={2}
-                        alignItems="center"
-                        justifyContent="start"
-                        border={1}
-                        borderRadius={2}
-                        key={currentGroup}
-                    >
-                        <h3>{currentGroup}</h3>
-                        <Stack key={`${currentGroup}-stack`} spacing={2}>
-                        {items
-                            .filter(x => x.group === currentGroup)
-                            .map((currentItem) => (
-                                <ItemCard key={`${currentItem._id}-itemCard`} item={currentItem} />
-                            ))}
-                        </Stack>
-                    </Box>
-                ))}
+                {groupMode ? renderGroups() : renderItems()}
             </Grid>
         </Box>
     )

--- a/src/features/items/itemsSlice.js
+++ b/src/features/items/itemsSlice.js
@@ -19,11 +19,12 @@ const itemsSlice = createSlice({
         builder
             .addMatcher(apiSlice.endpoints.getItems.matchFulfilled, (state, { payload }) => {
                 payload.forEach(resItem => {
-
-                    // TODO: Map groups
-
                     const idx = state.items.findIndex(i => i._id === resItem._id)
                     idx != -1 ? state.items.splice(idx, 1, resItem) : state.items.push(resItem)
+
+                    const gIdx = state.groups.findIndex(i => i === resItem.group)
+                    if (gIdx === -1 && resItem.group)
+                        state.groups.push(resItem.group)
                 });
             })
             .addMatcher(apiSlice.endpoints.updateItem.matchFulfilled, (state, { payload }) => {
@@ -36,9 +37,6 @@ const itemsSlice = createSlice({
                 }
             })
             .addMatcher(apiSlice.endpoints.deleteItem.matchFulfilled, (state, { meta }) => {
-
-                // TODO: If deleteItem was only one with group, remove the group
-
                 const delIdx = state.items.findIndex(x => x._id === meta.originalArgs)
                 state.items.splice(delIdx, 1)
             })

--- a/src/features/items/itemsSlice.js
+++ b/src/features/items/itemsSlice.js
@@ -3,36 +3,48 @@ import { apiSlice } from "../api/apiSlice"
 
 const itemsSlice = createSlice({
     name: 'items',
-    initialState: [],
+    initialState: {
+        items: [],
+        groups: []
+    },
     reducers: {
-        add: (state, action) => {
-            state.push(action.item)
+        addItem: (state, action) => {
+            state.items.push(action.item)
         },
-        remove: (state, action) => {
-            state.filter(x => x.id !== action.item.id)
+        removeItem: (state, action) => {
+            state.items.filter(x => x.id !== action.item.id)
         }
     },
     extraReducers: builder => {
         builder
             .addMatcher(apiSlice.endpoints.getItems.matchFulfilled, (state, { payload }) => {
                 payload.forEach(resItem => {
-                    const idx = state.findIndex(i => i._id === resItem._id)
-                    idx != -1 ? state.splice(idx, 1, resItem) : state.push(resItem)
+
+                    // TODO: Map groups
+
+                    const idx = state.items.findIndex(i => i._id === resItem._id)
+                    idx != -1 ? state.items.splice(idx, 1, resItem) : state.items.push(resItem)
                 });
             })
             .addMatcher(apiSlice.endpoints.updateItem.matchFulfilled, (state, { payload }) => {
                 if (payload?.dbResponse?.acknowledged) {
-                    const updatedIdx = state.findIndex(x => x._id === payload.updatedItem._id)
-                    state[updatedIdx] = { ...payload.updatedItem }
+
+                    // TODO: Check for group change/update
+
+                    const updatedIdx = state.items.findIndex(x => x._id === payload.updatedItem._id)
+                    state.items[updatedIdx] = { ...payload.updatedItem }
                 }
             })
             .addMatcher(apiSlice.endpoints.deleteItem.matchFulfilled, (state, { meta }) => {
-                const delIdx = state.findIndex(x => x._id === meta.originalArgs)
-                state.splice(delIdx, 1)
+
+                // TODO: If deleteItem was only one with group, remove the group
+
+                const delIdx = state.items.findIndex(x => x._id === meta.originalArgs)
+                state.items.splice(delIdx, 1)
             })
     }
 })
 
-export const { add, remove } = itemsSlice.actions
+export const { addItem, removeItem } = itemsSlice.actions
 
 export default itemsSlice.reducer


### PR DESCRIPTION
Add a new menu option to change from displaying items in an unordered list, or in columns by group.

Verified with "some" and "lots" of seed data. The group container(s) are auto height, and consistent. The height of all groups is determined by the height of the group with the most amount of items.

The selected "groupMode" is stored in localStorage similar to the "darkMode" setting.

Resolves #4 